### PR TITLE
fix: correct CMakeLists, .vscode, and .gitignore for cross-platform builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build/
+esp/
+.DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
+  "clangd.arguments": [
+    "--background-index",
+    "--query-driver=**"
+  ],
   "idf.openOcdConfigs": [
     "board/esp32s3-builtin.cfg"
   ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,4 @@
 {
-  "idf.currentSetup": "C:\\esp\\v5.5.4\\esp-idf",
-  "clangd.path": "C:\\Espressif\\tools\\esp-clang\\esp-20.1.1_20250829\\esp-clang\\bin\\clangd.exe",
-  "clangd.arguments": [
-    "--background-index",
-    "--query-driver=**",
-    "--compile-commands-dir=c:\\Users\\gabri\\Desktop\\privacy-shield\\build"
-  ],
   "idf.openOcdConfigs": [
     "board/esp32s3-builtin.cfg"
   ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,13 @@
 {
+  "C_Cpp.intelliSenseEngine": "default",
   "clangd.arguments": [
     "--background-index",
-    "--query-driver=**"
+    "--query-driver=**",
+    "--compile-commands-dir=${workspaceFolder}/build"
   ],
+  "idf.customExtraVars": {
+    "IDF_TARGET": "esp32s3"
+  },
   "idf.openOcdConfigs": [
     "board/esp32s3-builtin.cfg"
   ]

--- a/components/audio_hal/CMakeLists.txt
+++ b/components/audio_hal/CMakeLists.txt
@@ -1,3 +1,3 @@
-idf_component_register(SRCS "audio_hal.c"
+idf_component_register(SRCS "i2s_mic.c" "max_amp.c"
                        INCLUDE_DIRS "include"
                        REQUIRES driver)

--- a/components/dsp_engine/CMakeLists.txt
+++ b/components/dsp_engine/CMakeLists.txt
@@ -1,2 +1,2 @@
-idf_component_register(SRCS "dsp_engine.c"
+idf_component_register(SRCS "aec_filter.c" "noise_gen.c" "vad.c"
                        INCLUDE_DIRS "include")

--- a/components/mesh_core/CMakeLists.txt
+++ b/components/mesh_core/CMakeLists.txt
@@ -1,3 +1,3 @@
-idf_component_register(SRCS "mesh_core.c"
+idf_component_register(SRCS "esp_now_link.c" "node_discovery.c"
                        INCLUDE_DIRS "include"
                        REQUIRES esp_wifi esp_netif)

--- a/components/web_dashboard/CMakeLists.txt
+++ b/components/web_dashboard/CMakeLists.txt
@@ -1,3 +1,3 @@
-idf_component_register(SRCS "web_dashboard.c"
+idf_component_register(SRCS "web_api.c" "web_server.c"
                        INCLUDE_DIRS "include"
                        REQUIRES esp_http_server)


### PR DESCRIPTION
Quick fixes found while reviewing the `sprint-1` setup:

1. **CMakeLists.txt** — SRCS now reference the actual files that exist
2. **.vscode/settings.json** — removed hardcoded Windows paths
3. **.gitignore** — added `esp/` (build artifacts) and `.DS_Store`

See review comments on PR #28 for details.