### PR TITLE
ci: add labeler configuration file to main

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,13 @@
+# .github/labeler.yml
+documentation:
+  - changed-files:
+      - any-glob-match-pattern: 'docs/**'
+      - any-glob-match-pattern: '*.md'
+
+bug:
+  - changed-files:
+      - any-glob-match-pattern: 'src/**'
+
+feature:
+  - changed-files:
+      - any-glob-match-pattern: 'src/**'


### PR DESCRIPTION
## Problem

The Labeler workflow (`.github/workflows/label.yml`) uses `pull_request_target`, which runs the workflow **from the base branch's code**. It looks for `.github/labeler.yml` but that file doesn't exist in `main` yet — it was only added in PR #31's diff (and with a typo'd filename `labler.yaml`), so the CI label check consistently fails with:

> The config file was not found at .github/labeler.yml

## Fix

Add `.github/labeler.yml` directly to `main` so the labeler action can find it when processing PRs targeting main (including #31).

## Once merged

PR #31 and any future PRs targeting `main` will have a passing label check.