### PR TITLE
sync: merge main into sprint-1 (CI updates)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Build firmware (ESP-IDF v5.4)
         uses: espressif/esp-idf-ci-action@v1
         with:
-          esp_idf_version: v5.4
+          esp_idf_version: v5.5.4
           target: esp32s3
           command: idf.py build
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "sprint-1" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "sprint-1" ]
   schedule:
     - cron: '24 5 * * 0'
 


### PR DESCRIPTION
## Sync PR — main → sprint-1

Main has 2 commits that sprint-1 is missing:

- `6d25cf4` Update ESP-IDF version to v5.5.4
- `34bd2a2` Add sprint-1 branch to CodeQL workflow triggers

**One conflict** in `.github/workflows/build.yml` — take `v5.5.4` from main (sprint-1 has `v5.4`).